### PR TITLE
Consolidating default device to CUDA when available

### DIFF
--- a/tests/api_tests/cuda/test_cuda_add_documents.py
+++ b/tests/api_tests/cuda/test_cuda_add_documents.py
@@ -259,11 +259,8 @@ class TestAddDocuments(MarqoTestCase):
         cuda_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cuda", expose_facets=True)['_tensor_facets'][0]["_embedding"]
         default_vec = self.client.index(self.index_name_1).get_document(document_id="default_device", expose_facets=True)['_tensor_facets'][0]["_embedding"]
 
-        print(f"cpu_vec: {cpu_vec[:5]}")
-        print(f"cuda_vec: {cuda_vec[:5]}")
-        print(f"default_vec: {default_vec[:5]}")
-
         # Confirm that CUDA was used by default.
+        # CUDA-computed vectors are slightly different from CPU-computed vectors
         assert not np.allclose(np.array(cpu_vec), np.array(default_vec), atol=1e-5)
         assert np.allclose(np.array(cuda_vec), np.array(default_vec), atol=1e-5)
 

--- a/tests/api_tests/cuda/test_cuda_add_documents.py
+++ b/tests/api_tests/cuda/test_cuda_add_documents.py
@@ -12,7 +12,6 @@ from unittest import mock
 @pytest.mark.cuda_test
 class TestAddDocuments(MarqoTestCase):
 
-    # NOTE: test_add_documents_default_device has been removed from these cuda tests
     def setUp(self) -> None:
         self.client = Client(**self.client_settings)
         self.index_name_1 = "my-test-index-1"
@@ -160,8 +159,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_with_device(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -177,8 +174,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_with_device_batching(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -194,8 +189,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_set_refresh(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)

--- a/tests/api_tests/cuda/test_cuda_add_documents.py
+++ b/tests/api_tests/cuda/test_cuda_add_documents.py
@@ -249,7 +249,7 @@ class TestAddDocuments(MarqoTestCase):
             }
         }
 
-        self.client.create_index(index_name, settings_dict=index_settings)
+        self.client.create_index(self.index_name_1, settings_dict=index_settings)
 
         self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cpu", "title": "blah"}], device="cpu")
         self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cuda", "title": "blah"}], device="cuda")

--- a/tests/api_tests/cuda/test_cuda_add_documents.py
+++ b/tests/api_tests/cuda/test_cuda_add_documents.py
@@ -235,8 +235,8 @@ class TestAddDocuments(MarqoTestCase):
 
         args, kwargs = mock__post.call_args
         assert "processes=12" not in kwargs["path"]
-    
-     def test_add_documents_defaults_to_cuda(self):
+
+    def test_add_documents_defaults_to_cuda(self):
         """
             Ensures that when cuda is available, when we send an add docs request with no device,
             cuda is selected as default and used for this.

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -209,8 +209,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_with_device(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -226,8 +224,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_with_device_batching(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -260,8 +256,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_set_refresh(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -350,7 +350,7 @@ class TestAddDocumentsCPUOnly(MarqoTestCase):
         """
             Ensures that when cuda is NOT available, an error is thrown when trying to use cuda
         """
-        self.client.create_index(self.index_name_1, settings_dict=index_settings)
+        self.client.create_index(self.index_name_1)
 
         # Add docs with CUDA must fail if CUDA is not available
         try:

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -337,18 +337,16 @@ class TestAddDocumentsCPUOnly(MarqoTestCase):
         self.client.create_index(self.index_name_1, settings_dict=index_settings)
 
         self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cpu", "title": "blah"}], device="cpu")
-        self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cuda", "title": "blah"}], device="cuda")
         self.client.index(self.index_name_1).add_documents([{"_id": "default_device", "title": "blah"}])
 
-        cpu_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cpu", expose_facets=True)['_tensor_facets'][0]["_embedding"]
-        
         # Add docs with CUDA must fail if CUDA is not available
         try:
-            cuda_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cuda", expose_facets=True)['_tensor_facets'][0]["_embedding"]
+            self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cuda", "title": "blah"}], device="cuda")
             raise AssertionError
         except MarqoWebError:
             pass
         
+        cpu_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cpu", expose_facets=True)['_tensor_facets'][0]["_embedding"]
         default_vec = self.client.index(self.index_name_1).get_document(document_id="default_device", expose_facets=True)['_tensor_facets'][0]["_embedding"]
 
         # Confirm that CPU was used by default.

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -7,6 +7,7 @@ from tests.marqo_test import MarqoTestCase
 from marqo import enums
 from unittest import mock
 import numpy as np
+import pytest
 
 class TestAddDocuments(MarqoTestCase):
 

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -349,7 +349,6 @@ class TestAddDocumentsCPUOnly(MarqoTestCase):
         except MarqoWebError:
             pass
         
-        
         default_vec = self.client.index(self.index_name_1).get_document(document_id="default_device", expose_facets=True)['_tensor_facets'][0]["_embedding"]
 
         # Confirm that CPU was used by default.

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -344,7 +344,7 @@ class TestAddDocumentsCPUOnly(MarqoTestCase):
         cuda_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cuda", expose_facets=True)['_tensor_facets'][0]["_embedding"]
         default_vec = self.client.index(self.index_name_1).get_document(document_id="default_device", expose_facets=True)['_tensor_facets'][0]["_embedding"]
 
-        # Confirm that CUDA was used by default.
-        # CUDA-computed vectors are slightly different from CPU-computed vectors
-        assert not np.allclose(np.array(cpu_vec), np.array(default_vec), atol=1e-5)
-        assert np.allclose(np.array(cuda_vec), np.array(default_vec), atol=1e-5)
+        # Confirm that CPU was used by default.
+        # CPU-computed vectors are slightly different from CUDA-computed vectors
+        assert np.allclose(np.array(cpu_vec), np.array(default_vec), atol=1e-5)
+        assert not np.allclose(np.array(cuda_vec), np.array(default_vec), atol=1e-5)

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -241,13 +241,10 @@ class TestAddDocuments(MarqoTestCase):
         for args, kwargs in mock__post.call_args_list:
             assert "device=cuda37" in kwargs["path"]
 
-    def test_add_documents_default_device(self):
-        """do we use the default device defined in the client, if it isn't
-        overridden?
+    def test_add_documents_no_device(self):
+        """No device should be in path if no device is set
         """
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = "cuda:28"
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -259,7 +256,7 @@ class TestAddDocuments(MarqoTestCase):
         assert run()
 
         args, kwargs = mock__post.call_args
-        assert "device=cuda28" in kwargs["path"]
+        assert "device" not in kwargs["path"]
 
     def test_add_documents_set_refresh(self):
         temp_client = copy.deepcopy(self.client)

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -321,11 +321,6 @@ class TestAddDocumentsCPUOnly(MarqoTestCase):
         except MarqoApiError as s:
             pass
 
-    @classmethod
-    def tearDownClass(self):
-        pass
-        # eject models
-
     def test_add_documents_defaults_to_cpu(self):
         """
             Ensures that when cuda is NOT available, when we send an add docs request with no device,

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -352,7 +352,7 @@ class TestBulkSearchCPUOnly(MarqoTestCase):
         """
             Ensures that when cuda is NOT available, an error is thrown when trying to use cuda
         """
-        self.client.create_index(self.index_name_1, settings_dict=index_settings)
+        self.client.create_index(self.index_name_1)
 
         # Add docs with CUDA must fail if CUDA is not available
         try:

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -148,11 +148,9 @@ class TestBulkSearch(MarqoTestCase):
         assert self.client.index(self.index_name_1).search(
             '"captain"')["hits"][0]["_id"] == "123456"
 
-    def test_search_with_device(self):
-        """use default as defined in config unless overridden"""
+    def test_search_with_no_device(self):
+        """device should not be in path"""
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = "cpu:4"
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -168,10 +166,10 @@ class TestBulkSearch(MarqoTestCase):
             return True
         assert run()
 
-        # did we use the defined default device?
+        # make sure we did not send any device
         args, _ = mock__post.call_args_list[0]
-        assert "device=cpu4" in args[0]
-        # did we overrride the default device?
+        assert "device" not in args[0]
+        # make sure we do send device explicitly
         args, _ = mock__post.call_args_list[1]
         assert "device=cuda2" in args[0]
 

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -169,7 +169,7 @@ class TestBulkSearch(MarqoTestCase):
         # make sure we did not send any device
         args, _ = mock__post.call_args_list[0]
         assert "device" not in args[0]
-        # make sure we do send device explicitly
+        # make sure we do send device (if explicitly set)
         args, _ = mock__post.call_args_list[1]
         assert "device=cuda2" in args[0]
 

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -8,7 +8,7 @@ import requests
 import random
 import math
 from tests.marqo_test import MarqoTestCase
-
+import pytest
 
 class TestBulkSearch(MarqoTestCase):
 

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -3,7 +3,7 @@ import marqo
 from marqo import enums
 from unittest import mock
 from marqo.client import Client
-from marqo.errors import MarqoApiError
+from marqo.errors import MarqoApiError, MarqoWebError
 import requests
 import random
 import math

--- a/tests/api_tests/test_config.py
+++ b/tests/api_tests/test_config.py
@@ -12,11 +12,6 @@ class TestConfig(MarqoTestCase):
     def setUp(self) -> None:
         self.endpoint = self.authorized_url
 
-    def test_init_custom_devices(self):
-        c = config.Config(url=self.endpoint,indexing_device="cuda:3", search_device="cuda:4")
-        assert c.indexing_device == "cuda:3"
-        assert c.search_device == "cuda:4"
-
     def test_url_is_s2search(self):
         c = config.Config(url="https://s2search.io/abdcde:8882")
         assert c.cluster_is_s2search

--- a/tests/api_tests/test_neural_search.py
+++ b/tests/api_tests/test_neural_search.py
@@ -108,11 +108,9 @@ class TestAddDocuments(MarqoTestCase):
         assert self.client.index(self.index_name_1).search(
             '"captain"')["hits"][0]["_id"] == "123456"
 
-    def test_search_with_device(self):
+    def test_search_with_no_device(self):
         """use default as defined in config unless overridden"""
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = "cpu:4"
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -123,7 +121,7 @@ class TestAddDocuments(MarqoTestCase):
         assert run()
         # did we use the defined default device?
         args, kwargs0 = mock__post.call_args_list[0]
-        assert "device=cpu4" in kwargs0["path"]
+        assert "device" not in kwargs0["path"]
         # did we overrride the default device?
         args, kwargs1 = mock__post.call_args_list[1]
         assert "device=cuda2" in kwargs1["path"]

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -8,6 +8,7 @@ import unittest
 import pprint
 from tests.marqo_test import MarqoTestCase
 from tests.utilities import disallow_environments
+import pytest
 
 class TestSearch(MarqoTestCase):
 

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -274,7 +274,7 @@ class TestSearchCPUOnly(MarqoTestCase):
         """
             Ensures that when cuda is NOT available, an error is thrown when trying to use cuda
         """
-        self.client.create_index(self.index_name_1, settings_dict=index_settings)
+        self.client.create_index(self.index_name_1)
 
         # Add docs with CUDA must fail if CUDA is not available
         try:

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -252,3 +252,32 @@ class TestSearch(MarqoTestCase):
 
         self.assertEqual(custom_score, original_score)
         
+@pytest.mark.cpu_only_test
+class TestSearchCPUOnly(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def tearDown(self) -> None:
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def test_search_device_not_available(self):
+        """
+            Ensures that when cuda is NOT available, an error is thrown when trying to use cuda
+        """
+        self.client.create_index(self.index_name_1, settings_dict=index_settings)
+
+        # Add docs with CUDA must fail if CUDA is not available
+        try:
+            self.client.index(self.index_name_1).search(q="blah", device="cuda")
+            raise AssertionError
+        except MarqoWebError:
+            pass

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -9,7 +9,7 @@ import pprint
 from tests.marqo_test import MarqoTestCase
 from tests.utilities import disallow_environments
 
-class TestAddDocuments(MarqoTestCase):
+class TestSearch(MarqoTestCase):
 
     def setUp(self) -> None:
         self.client = Client(**self.client_settings)
@@ -119,10 +119,10 @@ class TestAddDocuments(MarqoTestCase):
             temp_client.index(self.index_name_1).search(q="my search term", device="cuda:2")
             return True
         assert run()
-        # did we use the defined default device?
+        # no device in path when device is not set
         args, kwargs0 = mock__post.call_args_list[0]
         assert "device" not in kwargs0["path"]
-        # did we overrride the default device?
+        # device in path if it is set
         args, kwargs1 = mock__post.call_args_list[1]
         assert "device=cuda2" in kwargs1["path"]
 

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -3,7 +3,7 @@ import marqo
 from marqo import enums
 from unittest import mock
 from marqo.client import Client
-from marqo.errors import MarqoApiError
+from marqo.errors import MarqoApiError, MarqoWebError
 import unittest
 import pprint
 from tests.marqo_test import MarqoTestCase

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,17 @@ import os
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "cuda_test: mark test as cuda_test to skip")
-    config.addinivalue_line("markers", "non_cuda_test: mark test as non_cuda_test to skip")
+    config.addinivalue_line("markers", "cpu_only_test: mark test as cpu_only_test to skip")
 
 
 def pytest_collection_modifyitems(items):
     if os.environ["TESTING_CONFIGURATION"] in ["CUDA_DIND_MARQO_OS"]:
-        # Skip non-cuda-tests if the env is CUDA
-        skip_non_cuda_test = pytest.mark.skip(reason="need to not set "
+        # Skip cpu_only_tests if the env is CUDA
+        skip_cpu_only_test = pytest.mark.skip(reason="need to not set "
                                                      "'TESTING_CONFIGURATION=CUDA_DIND_MARQO_OS' to run")
         for item in items:
-            if "non_cuda_test" in item.keywords:
-                item.add_marker(skip_non_cuda_test)
+            if "cpu_only_test" in item.keywords:
+                item.add_marker(skip_cpu_only_test)
     else:
         # Skip cuda-tests if the env is NOT CUDA
         skip_cuda_test = pytest.mark.skip(reason="need to setEnvVars "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,21 @@ import os
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "cuda_test: mark test as cuda_test to skip")
+    config.addinivalue_line("markers", "non_cuda_test: mark test as non_cuda_test to skip")
 
 
 def pytest_collection_modifyitems(items):
     if os.environ["TESTING_CONFIGURATION"] in ["CUDA_DIND_MARQO_OS"]:
-        return
-    skip_cuda_test = pytest.mark.skip(reason="need to setEnvVars "
-                                             "'TESTING_CONFIGURATION=CUDA_DIND_MARQO_OS' to run")
-    for item in items:
-        if "cuda_test" in item.keywords:
-            item.add_marker(skip_cuda_test)
+        # Skip non-cuda-tests if the env is CUDA
+        skip_non_cuda_test = pytest.mark.skip(reason="need to not set "
+                                                     "'TESTING_CONFIGURATION=CUDA_DIND_MARQO_OS' to run")
+        for item in items:
+            if "non_cuda_test" in item.keywords:
+                item.add_marker(skip_non_cuda_test)
+    else:
+        # Skip cuda-tests if the env is NOT CUDA
+        skip_cuda_test = pytest.mark.skip(reason="need to setEnvVars "
+                                                 "'TESTING_CONFIGURATION=CUDA_DIND_MARQO_OS' to run")
+        for item in items:
+            if "cuda_test" in item.keywords:
+                item.add_marker(skip_cuda_test)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Client has no more default device, Marqo defaults to best available device.

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/marqo-ai/marqo/issues/480

* **What is the new behavior (if this is a feature change)?**
This marqo PR: https://github.com/marqo-ai/marqo/pull/508/files

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

