### PR TITLE
Disable auto create index

### DIFF
--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -139,6 +139,7 @@ class TestAddDocuments(MarqoTestCase):
         assert d2 == self.client.index(self.index_name_1).get_document("56")
 
     def test_add_batched_documents(self):
+        self.client.create_index(index_name=self.index_name_1)
         ix = self.client.index(index_name=self.index_name_1)
         doc_ids = [str(num) for num in range(0, 100)]
         docs = [
@@ -198,15 +199,11 @@ class TestAddDocuments(MarqoTestCase):
 
     # user experience tests:
 
-    def test_add_documents_implicitly_create_index(self):
-        try:
-            self.client.index(self.index_name_1).search("some str")
-            raise AssertionError
-        except MarqoWebError as s:
-            assert "index_not_found" == s.code
-        self.client.index(self.index_name_1).add_documents([{"abd": "efg"}])
-        # it works:
-        self.client.index(self.index_name_1).search("some str")
+    def test_add_documents_missing_index_fails(self):
+        with pytest.raises(MarqoWebError) as ex:
+            self.client.index(self.index_name_1).add_documents([{"abd": "efg"}])
+
+        assert "index_not_found" == ex.value.code
 
     def test_add_documents_with_device(self):
         temp_client = copy.deepcopy(self.client)

--- a/tests/api_tests/test_demos.py
+++ b/tests/api_tests/test_demos.py
@@ -20,6 +20,7 @@ class TestDemo(MarqoTestCase):
 
     def test_demo(self):
         client = Client(**self.client_settings)
+        client.create_index("cool-index-1")
         client.index("cool-index-1").add_documents([
             {
                 "Title": "The Legend of the River",
@@ -49,6 +50,8 @@ class TestDemo(MarqoTestCase):
         import marqo
 
         mq = marqo.Client(url=self.authorized_url, main_user="admin", main_password="admin")
+
+        mq.create_index("my-first-index")
 
         mq.index("my-first-index").add_documents([
             {

--- a/tests/api_tests/test_parallel.py
+++ b/tests/api_tests/test_parallel.py
@@ -35,7 +35,9 @@ class TestAddDocumentsPara(MarqoTestCase):
         identifiers = self.identifiers
         data = self.data
 
-        res = self.client.index(self.index_name_1).add_documents(data, **self.para_params)
+        self.client.create_index(self.index_name_1)
+
+        self.client.index(self.index_name_1).add_documents(data, **self.para_params)
 
         time.sleep(self.sleep)
 
@@ -54,7 +56,9 @@ class TestAddDocumentsPara(MarqoTestCase):
         identifiers = self.identifiers
         data = self.data
 
-        res = self.client.index(self.index_name_1).add_documents(data, **self.para_params)
+        self.client.create_index(self.index_name_1)
+
+        self.client.index(self.index_name_1).add_documents(data, **self.para_params)
 
         time.sleep(self.sleep)
 

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -162,6 +162,7 @@ class TestSearch(MarqoTestCase):
             "dont#tensorise Me": "Dog",
             "tensorise_me": "quarterly earnings report"
         }]
+        self.client.create_index(self.index_name_1)
         self.client.index(index_name=self.index_name_1).add_documents(
             docs, auto_refresh=True, non_tensor_fields=["dont#tensorise Me"]
         )

--- a/tests/application_tests/test_env_var_changes.py
+++ b/tests/application_tests/test_env_var_changes.py
@@ -133,4 +133,3 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         # Assert correct models
         res = self.client.get_loaded_models()
         assert set([item["model_name"] for item in res["models"]]) == set(new_models)
-

--- a/tests/application_tests/test_start_stop.py
+++ b/tests/application_tests/test_start_stop.py
@@ -35,6 +35,7 @@ class TestStartStop(marqo_test.MarqoTestCase):
 
             d1 = {"Title": "The colour of plants", "_id": "fact_1"}
             d2 = {"Title": "some frogs", "_id": "fact_2"}
+            self.client.create_index(self.index_name_1)
             self.client.index(self.index_name_1).add_documents(documents=[d1, d2])
             search_res_0 = self.client.index(self.index_name_1).search(q="General nature facts")
             assert (search_res_0["hits"][0]["_id"] == "fact_1") or (search_res_0["hits"][0]["_id"] == "fact_2")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
When adding documents to an index that does not exist, Marqo automatically and silently creates an index with a default index configuration.

* **What is the new behavior (if this is a feature change)?**
Attempting to add documents to an index that does not exist will fail with an error. Indices must be created explicitly before adding documents.
See https://github.com/marqo-ai/marqo/pull/516

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Users must ensure an index exists before documents are added, or must handle the error. Code that relies on the removed automatic index creation behaviour will fail.

* **Other information**:

