### PR TITLE
Added escape to filter tests, changed cuda neural search file name

### DIFF
--- a/tests/api_tests/cuda/test_cuda_search.py
+++ b/tests/api_tests/cuda/test_cuda_search.py
@@ -12,7 +12,7 @@ import pytest
 
 
 @pytest.mark.cuda_test
-class TestAddDocuments(MarqoTestCase):
+class TestSearch(MarqoTestCase):
 
     # NOTE: test_search_with_device was removed from these cuda tests
     # NOTE: Try this solo again if needed -> @allow_environments(["CUDA_DIND_MARQO_OS"])
@@ -134,7 +134,8 @@ class TestAddDocuments(MarqoTestCase):
         ], device="cuda",auto_refresh=True)
         search_res = self.client.index(self.index_name_1).search(
             "blah blah",
-            filter_string="(an_int:[0 TO 30] and an_int:2) AND abc-123:(some text)",
+            # NOTE: There is an escaped dash in the filter string
+            filter_string="(an_int:[0 TO 30] and an_int:2) AND abc\\-123:(some text)",
             device="cuda")
         assert len(search_res["hits"]) == 1
         pprint.pprint(search_res)

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -195,7 +195,8 @@ class TestBulkSearch(MarqoTestCase):
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "blah blah",
-            "filter": "(an_int:[0 TO 30] and an_int:2) AND abc-123:(some text)"
+            # note: filter has escaped character (-)
+            "filter": "(an_int:[0 TO 30] and an_int:2) AND abc\\-123:(some text)"
         }])
         assert len(resp['result']) == 1
         search_res = resp['result'][0]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Test patch

* **What is the current behavior?** (You can also link to an open issue here)
broken test because of lack of escape character in filtering

* **What is the new behavior (if this is a feature change)?**
- added escape (both search and bulk search)
- changed cuda_neural_search.py to cuda_search.py

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

