### PR TITLE
Update tests to work with py-marqo 1.0.0 changes

### DIFF
--- a/tests/api_tests/cuda/test_cuda_add_documents.py
+++ b/tests/api_tests/cuda/test_cuda_add_documents.py
@@ -43,7 +43,7 @@ class TestAddDocuments(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], device="cuda")
+        ], device="cuda", non_tensor_fields=[])
         retrieved_d1 = self.client.index(self.index_name_1).get_document(document_id="e197e580-0393-4f4e-90e9-8cdf4b17e339")
         assert retrieved_d1 == d1
         retrieved_d2 = self.client.index(self.index_name_1).get_document(document_id="123456")
@@ -60,7 +60,7 @@ class TestAddDocuments(MarqoTestCase):
                 "doc title": "Just Your Average Doc",
                 "field X": "this is a solid doc"
             }
-        res = self.client.index(self.index_name_1).add_documents([d1, d2], device="cuda")
+        res = self.client.index(self.index_name_1).add_documents([d1, d2], device="cuda", non_tensor_fields=[])
         ids = [item["_id"] for item in res["items"]]
         assert len(ids) == 2
         assert ids[0] != ids[1]
@@ -78,14 +78,14 @@ class TestAddDocuments(MarqoTestCase):
             "field X": "this is a solid doc",
             "_id": "56"
         }
-        self.client.index(self.index_name_1).add_documents([d1], device="cuda")
+        self.client.index(self.index_name_1).add_documents([d1], device="cuda", non_tensor_fields=[])
         assert d1 == self.client.index(self.index_name_1).get_document("56")
         d2 = {
             "_id": "56",
             "completely": "different doc.",
             "field X": "this is a solid doc"
         }
-        self.client.index(self.index_name_1).add_documents([d2], device="cuda")
+        self.client.index(self.index_name_1).add_documents([d2], device="cuda", non_tensor_fields=[])
         assert d2 == self.client.index(self.index_name_1).get_document("56")
 
     def test_add_batched_documents(self):
@@ -98,7 +98,7 @@ class TestAddDocuments(MarqoTestCase):
              "_id": doc_id}
             for doc_id in doc_ids]
 
-        ix.add_documents(docs, device="cuda")
+        ix.add_documents(docs, device="cuda", non_tensor_fields=[])
         ix.refresh()
         # TODO we should do a count in here...
         # takes too long to search for all
@@ -119,7 +119,7 @@ class TestAddDocuments(MarqoTestCase):
         self.client.index(self.index_name_1).add_documents([
             {"abc": "wow camel", "_id": "123"},
             {"abc": "camels are cool", "_id": "foo"}
-        ], device="cuda")
+        ], device="cuda", non_tensor_fields=[])
         res0 = self.client.index(self.index_name_1).search("wow camel", device="cuda")
         print("res0res0")
         pprint.pprint(res0)
@@ -132,7 +132,8 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_delete_docs_empty_ids(self):
         self.client.create_index(index_name=self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"abc": "efg", "_id": "123"}], device="cuda")
+        self.client.index(self.index_name_1).add_documents([{"abc": "efg", "_id": "123"}], device="cuda",
+                                                           non_tensor_fields=[])
         try:
             self.client.index(self.index_name_1).delete_documents([])
             raise AssertionError
@@ -157,7 +158,7 @@ class TestAddDocuments(MarqoTestCase):
         def run():
             temp_client.index(self.index_name_1).add_documents(documents=[
                 {"d1": "blah"}, {"d2", "some data"}
-            ], device="cuda:45")
+            ], device="cuda:45", non_tensor_fields=[])
             return True
         assert run()
 
@@ -172,10 +173,10 @@ class TestAddDocuments(MarqoTestCase):
         def run():
             temp_client.index(self.index_name_1).add_documents(documents=[
                 {"d1": "blah"}, {"d2", "some data"}
-            ], device="cuda", auto_refresh=False)
+            ], device="cuda", auto_refresh=False, non_tensor_fields=[])
             temp_client.index(self.index_name_1).add_documents(documents=[
                 {"d1": "blah"}, {"d2", "some data"}
-            ], device="cuda", auto_refresh=True)
+            ], device="cuda", auto_refresh=True, non_tensor_fields=[])
             return True
         assert run()
 
@@ -191,7 +192,7 @@ class TestAddDocuments(MarqoTestCase):
         def run():
             self.client.index(self.index_name_1).add_documents(documents=[
                 {"d1": "blah"}, {"d2", "some data"}
-            ], device="cuda")
+            ], device="cuda", non_tensor_fields=[])
             return True
         assert run()
 
@@ -213,9 +214,12 @@ class TestAddDocuments(MarqoTestCase):
 
         self.client.create_index(self.index_name_1, settings_dict=index_settings)
 
-        self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cpu", "title": "blah"}], device="cpu")
-        self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cuda", "title": "blah"}], device="cuda")
-        self.client.index(self.index_name_1).add_documents([{"_id": "default_device", "title": "blah"}])
+        self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cpu", "title": "blah"}], device="cpu",
+                                                           non_tensor_fields=[])
+        self.client.index(self.index_name_1).add_documents([{"_id": "explicit_cuda", "title": "blah"}], device="cuda",
+                                                           non_tensor_fields=[])
+        self.client.index(self.index_name_1).add_documents([{"_id": "default_device", "title": "blah"}],
+                                                           non_tensor_fields=[])
 
         cpu_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cpu", expose_facets=True)['_tensor_facets'][0]["_embedding"]
         cuda_vec = self.client.index(self.index_name_1).get_document(document_id="explicit_cuda", expose_facets=True)['_tensor_facets'][0]["_embedding"]

--- a/tests/api_tests/cuda/test_cuda_image_chunking.py
+++ b/tests/api_tests/cuda/test_cuda_image_chunking.py
@@ -47,7 +47,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (aking to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], device='cuda')
+        client.index(self.index_name).add_documents([document1], device='cuda', non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a', device="cuda")
@@ -90,7 +90,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], device='cuda')
+        client.index(self.index_name).add_documents([document1], device='cuda', non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a', device="cuda")

--- a/tests/api_tests/cuda/test_cuda_model_cache_management.py
+++ b/tests/api_tests/cuda/test_cuda_model_cache_management.py
@@ -74,7 +74,7 @@ class TestAddDocuments(MarqoTestCase):
             "doc title": "Cool Document 1",
             "field 1": "some extra info"
         }
-        self.client.index(self.index_name).add_documents([d1], device="cuda")
+        self.client.index(self.index_name).add_documents([d1], device="cuda", non_tensor_fields=[])
         self.client.eject_model(self.MODEL, "cuda")
 
 

--- a/tests/api_tests/cuda/test_cuda_search.py
+++ b/tests/api_tests/cuda/test_cuda_search.py
@@ -48,7 +48,7 @@ class TestSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], device='cuda')
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], device='cuda', non_tensor_fields=[])
         search_res = self.client.index(self.index_name_1).search(
             "title about some doc", device="cuda")
         assert len(search_res["hits"]) == 1
@@ -76,7 +76,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], device='cuda')
+        ], device='cuda', non_tensor_fields=[])
         search_res = self.client.index(self.index_name_1).search(
             "this is a solid doc", device="cuda")
         assert d2 == self.strip_marqo_fields(search_res['hits'][0], strip_id=False)
@@ -97,7 +97,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], device="cuda")
+        ], device="cuda", non_tensor_fields=[])
 
         # Ensure that vector search works
         search_res = self.client.index(self.index_name_1).search(
@@ -131,7 +131,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], device="cuda",auto_refresh=True)
+        ], device="cuda",auto_refresh=True, non_tensor_fields=[])
         search_res = self.client.index(self.index_name_1).search(
             "blah blah",
             # NOTE: There is an escaped dash in the filter string

--- a/tests/api_tests/cuda/test_cuda_sentence_chunking.py
+++ b/tests/api_tests/cuda/test_cuda_sentence_chunking.py
@@ -46,7 +46,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], device="cuda")
+        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a', device="cuda")
@@ -79,7 +79,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], device="cuda")
+        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[])
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'
@@ -127,7 +127,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], device="cuda")
+        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[])
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'

--- a/tests/api_tests/cuda/test_model_eject_and_concurrency.py
+++ b/tests/api_tests/cuda/test_model_eject_and_concurrency.py
@@ -63,7 +63,7 @@ class TestModelEject(MarqoTestCase):
                     "Description": "The EMU is a spacesuit that provides environmental protection, "
                                    "mobility, life support, and communications for astronauts",
                     "_id": "article_591"
-                }], auto_refresh=True, device=cls.device)
+                }], auto_refresh=True, device=cls.device, non_tensor_fields=[])
 
         time.sleep(10)
 
@@ -135,7 +135,7 @@ class TestConcurrencyRequestsBlock(MarqoTestCase):
                 "Description": "The EMU is a spacesuit that provides environmental protection, "
                                "mobility, life support, and communications for astronauts",
                 "_id": "article_591"
-            }], auto_refresh=True, device=self.device)
+            }], auto_refresh=True, device=self.device, non_tensor_fields=[])
 
     def tearDown(self) -> None:
         try:

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -46,7 +46,7 @@ class TestBulkSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1])
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[])
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "title about some doc"
@@ -73,7 +73,7 @@ class TestBulkSearch(MarqoTestCase):
     def test_search_highlights(self):
         """Tests if show_highlights works and if the deprecation behaviour is expected"""
         self.client.create_index(index_name=self.index_name_1)
-        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}])
+        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}], non_tensor_fields=[])
         for params, expected_highlights_presence in [
                 ({}, True),
                 ({"showHighlights": False}, False),
@@ -101,7 +101,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], non_tensor_fields=[])
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "this is a solid doc"
@@ -127,7 +127,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], non_tensor_fields=[])
 
         # Ensure that vector search works
         resp = self.client.bulk_search([{
@@ -190,7 +190,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ],auto_refresh=True)
+        ],auto_refresh=True, non_tensor_fields=[])
 
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
@@ -222,7 +222,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         x = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], auto_refresh=True)
+        ], auto_refresh=True, non_tensor_fields=[])
         atts = ["doc title", "an_int"]
         for search_method in [enums.SearchMethods.TENSOR,
                               enums.SearchMethods.LEXICAL]:
@@ -253,7 +253,7 @@ class TestBulkSearch(MarqoTestCase):
                         for i in range(num_docs)]
         
         self.client.index(index_name=self.index_name_1).add_documents(
-            docs, auto_refresh=False, client_batch_size=50
+            docs, auto_refresh=False, client_batch_size=50, non_tensor_fields=[]
         )
         self.client.index(index_name=self.index_name_1).refresh()
 
@@ -309,7 +309,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         self.client.create_index(index_name=self.index_name_1, settings_dict=image_index_config)
         self.client.index(index_name=self.index_name_1).add_documents(
-            documents=docs, auto_refresh=True
+            documents=docs, auto_refresh=True, non_tensor_fields=[]
         )
         queries_expected_ordering = [
             ({"Nature photography": 2.0, "Artefact": -2}, ['realistic_hippo', 'artefact_hippo']),

--- a/tests/api_tests/test_demos.py
+++ b/tests/api_tests/test_demos.py
@@ -38,7 +38,7 @@ class TestDemo(MarqoTestCase):
                 S2Search is based in Melbourne. Melbourne has beautiful waterways running through it.
                 """
             },
-        ])
+        ], non_tensor_fields=[])
         print("\nSearching the phrase 'River' across all fields")
         pprint.pprint(client.index("cool-index-1").search("River"))
         # then we search specific searchable attributes. We can see how powerful semantic search is
@@ -63,7 +63,7 @@ class TestDemo(MarqoTestCase):
                                "mobility, life support, and communications for astronauts",
                 "_id": "article_591"
             }
-        ])
+        ], non_tensor_fields=[])
 
         results = mq.index("my-first-index").search(
             q="What is the best outfit to wear on the moon?"

--- a/tests/api_tests/test_image_chunking.py
+++ b/tests/api_tests/test_image_chunking.py
@@ -49,7 +49,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (aking to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -92,7 +92,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -155,7 +155,7 @@ class TestImageChunking(MarqoTestCase):
             'location_1': temp_file_name_2},
         ]
 
-        client.index(self.index_name).add_documents(documents)
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('brain', searchable_attributes=['location', 'location_1'])
@@ -205,7 +205,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -255,7 +255,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -299,7 +299,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a')

--- a/tests/api_tests/test_image_reranking.py
+++ b/tests/api_tests/test_image_reranking.py
@@ -54,7 +54,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_statue.png'},
         ]
 
-        client.index(self.index_name).add_documents(documents)
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
 
         ###### proper way to search over images
         # test the search works
@@ -125,7 +125,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_statue.png'},
         ]
 
-        client.index(self.index_name).add_documents(documents)
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
 
         # test Errors
         # # test the search works with the reranking and no searchable attributes
@@ -165,7 +165,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_statue.png'},
         ]
 
-        res = client.index(self.index_name).add_documents(documents)
+        res = client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
         print(res)
 
         # test Errors
@@ -208,7 +208,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://raw.githubusercontent.com/marqo-ai/marqo-api-tests/mainline/assets/ai_hippo_statue.png'},
         ]
 
-        client.index(self.index_name).add_documents(documents)
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
 
         ###### proper way to search over images
         # test the search works

--- a/tests/api_tests/test_model_cache_management.py
+++ b/tests/api_tests/test_model_cache_management.py
@@ -73,7 +73,7 @@ class TestModlCacheManagement(MarqoTestCase):
             "doc title": "Cool Document 1",
             "field 1": "some extra info"
         }
-        self.client.index(self.index_name).add_documents([d1], device="cpu")
+        self.client.index(self.index_name).add_documents([d1], device="cpu", non_tensor_fields=[])
         self.client.eject_model(self.MODEL, "cpu")
 
 

--- a/tests/api_tests/test_model_eject_and_concurrency.py
+++ b/tests/api_tests/test_model_eject_and_concurrency.py
@@ -64,7 +64,7 @@ class TestModelEject(MarqoTestCase):
                     "Description": "The EMU is a spacesuit that provides environmental protection, "
                                    "mobility, life support, and communications for astronauts",
                     "_id": "article_591"
-                }], auto_refresh=True, device=cls.device)
+                }], auto_refresh=True, device=cls.device, non_tensor_fields=[])
 
         time.sleep(10)
 
@@ -136,7 +136,7 @@ class TestConcurrencyRequestsBlock(MarqoTestCase):
                 "Description": "The EMU is a spacesuit that provides environmental protection, "
                                "mobility, life support, and communications for astronauts",
                 "_id": "article_591"
-            }], auto_refresh=True, device=self.device)
+            }], auto_refresh=True, device=self.device, non_tensor_fields=[])
 
     def tearDown(self) -> None:
         try:

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -44,7 +44,7 @@ class TestSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1])
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[])
         search_res = self.client.index(self.index_name_1).search(
             "title about some doc")
         assert len(search_res["hits"]) == 1
@@ -72,7 +72,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], non_tensor_fields=[])
         search_res = self.client.index(self.index_name_1).search(
             "this is a solid doc")
         assert d2 == self.strip_marqo_fields(search_res['hits'][0], strip_id=False)
@@ -93,7 +93,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], non_tensor_fields=[])
 
         # Ensure that vector search works
         search_res = self.client.index(self.index_name_1).search(
@@ -158,7 +158,7 @@ class TestSearch(MarqoTestCase):
                 "int_for_filtering": 1,
             }
         ]
-        res = self.client.index(self.index_name_1).add_documents(docs,auto_refresh=True)
+        res = self.client.index(self.index_name_1).add_documents(docs,auto_refresh=True, non_tensor_fields=[])
 
         test_cases = (
             {   # filter string only (str)
@@ -247,7 +247,7 @@ class TestSearch(MarqoTestCase):
         }
         self.client.create_index(index_name=self.index_name_1, settings_dict=image_index_config)
         self.client.index(index_name=self.index_name_1).add_documents(
-            documents=docs, auto_refresh=True
+            documents=docs, auto_refresh=True, non_tensor_fields=[]
         )
         queries_expected_ordering = [
             ({"Nature photography": 2.0, "Artefact": -2}, ['realistic_hippo', 'artefact_hippo']),
@@ -286,7 +286,7 @@ class TestSearch(MarqoTestCase):
                     "Description": "A history of household pets",
                     "_id": "d2"
                 }
-            ]
+            ], non_tensor_fields=[]
         )
         query = {
             "What are the best pets": 1

--- a/tests/api_tests/test_sentence_chunking.py
+++ b/tests/api_tests/test_sentence_chunking.py
@@ -47,7 +47,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -80,7 +80,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'
@@ -128,7 +128,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'

--- a/tests/api_tests/test_special_chars_in_fieldnames_and_filters.py
+++ b/tests/api_tests/test_special_chars_in_fieldnames_and_filters.py
@@ -106,7 +106,7 @@ class TestFiltering(MarqoTestCase):
         add_docs_kwargs_to_test = [
             {"non_tensor_fields": ["filteringField"]},
             # all tensor fields:
-            dict()
+            {"non_tensor_fields": []}
         ]
         for add_docs_kwargs in add_docs_kwargs_to_test:
             for special_str in self.special_str_sequences:
@@ -128,7 +128,7 @@ class TestFiltering(MarqoTestCase):
         add_docs_kwargs_to_test = [
             {"non_tensor_fields": ["filteringField"]},
             # all tensor fields:
-            dict()
+            {"non_tensor_fields": []}
         ]
         # These search filter strings don't yet work. They will be skipped during the test
         filter_strs_that_dont_yet_work = [
@@ -465,6 +465,7 @@ class TestSpecialCharsFieldNames(MarqoTestCase):
         add_docs_result = self.client.index(self.index_name_1).add_documents(
             documents=docs,
             auto_refresh=True,
+            non_tensor_fields=[]
         )
         if add_docs_result['errors']:
             raise AssertionError(f"Error adding documents: {add_docs_result}, docs: {repr(docs)}")

--- a/tests/application_tests/test_asynchronous.py
+++ b/tests/application_tests/test_asynchronous.py
@@ -35,14 +35,15 @@ class TestAsync (marqo_test.MarqoTestCase):
             "_id": "56"
         }
         self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([d1])
+        self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[])
         assert self.client.index(self.index_name_1).get_stats()['numberOfDocuments'] == 1
 
         def significant_ingestion():
             docs = [{"Title": " ".join(random.choices(population=vocab, k=10)),
                           "Description": " ".join(random.choices(population=vocab, k=25)),
                           } for _ in range(num_docs)]
-            self.client.index(self.index_name_1).add_documents(documents=docs, auto_refresh=True, client_batch_size=1)
+            self.client.index(self.index_name_1).add_documents(documents=docs, auto_refresh=True, client_batch_size=1,
+                                                               non_tensor_fields=[])
 
         cache_update_thread = threading.Thread(
             target=significant_ingestion)

--- a/tests/application_tests/test_start_stop.py
+++ b/tests/application_tests/test_start_stop.py
@@ -40,7 +40,7 @@ class TestStartStop(marqo_test.MarqoTestCase):
             d2 = {"Title": "some frogs", "_id": "fact_2"}
             self._delete_index()
             self.client.create_index(self.index_name_1)
-            self.client.index(self.index_name_1).add_documents(documents=[d1, d2])
+            self.client.index(self.index_name_1).add_documents(documents=[d1, d2], non_tensor_fields=[])
             search_res_0 = self.client.index(self.index_name_1).search(q="General nature facts")
             assert (search_res_0["hits"][0]["_id"] == "fact_1") or (search_res_0["hits"][0]["_id"] == "fact_2")
             assert len(search_res_0["hits"]) == 2


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Most `add_documents` calls rely on the default py-marqo behaviour of treating all fields as tensor fields. With Marqo 1.0.0, py-marqo will raise an error for these and the tests will fail. 

* **What is the new behavior (if this is a feature change)?**
Explicitly define `non_tensor_fields=[]` for all such tests. Even though `non_tensor_fields` will be deprecated with v1.0.0, `tensor_fields` has not been used so that the tests pass for both 0.1.0 and 1.0.0. We will have to make this change later once 1.0.0 has been released.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

