### PR TITLE
Add auto_refresh=True to add and delete docs calls

### DIFF
--- a/tests/api_tests/cuda/test_cuda_add_documents.py
+++ b/tests/api_tests/cuda/test_cuda_add_documents.py
@@ -119,13 +119,11 @@ class TestAddDocuments(MarqoTestCase):
         self.client.index(self.index_name_1).add_documents([
             {"abc": "wow camel", "_id": "123"},
             {"abc": "camels are cool", "_id": "foo"}
-        ], device="cuda", non_tensor_fields=[])
+        ], device="cuda", non_tensor_fields=[], auto_refresh=True)
         res0 = self.client.index(self.index_name_1).search("wow camel", device="cuda")
-        print("res0res0")
-        pprint.pprint(res0)
         assert res0['hits'][0]["_id"] == "123"
         assert len(res0['hits']) == 2
-        self.client.index(self.index_name_1).delete_documents(["123"])
+        self.client.index(self.index_name_1).delete_documents(["123"], auto_refresh=True)
         res1 = self.client.index(self.index_name_1).search("wow camel", device="cuda")
         assert res1['hits'][0]["_id"] == "foo"
         assert len(res1['hits']) == 1

--- a/tests/api_tests/cuda/test_cuda_delete_documents.py
+++ b/tests/api_tests/cuda/test_cuda_delete_documents.py
@@ -1,0 +1,55 @@
+import copy
+import pprint
+
+import pytest
+from marqo.client import Client
+from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
+import unittest
+from tests.marqo_test import MarqoTestCase
+from marqo import enums
+from unittest import mock
+import numpy as np
+
+@pytest.mark.cuda_test
+class TestDeleteDocuments(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def tearDown(self) -> None:
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def test_delete_docs(self):
+        self.client.create_index(index_name=self.index_name_1)
+        self.client.index(self.index_name_1).add_documents([
+            {"abc": "wow camel", "_id": "123"},
+            {"abc": "camels are cool", "_id": "foo"}
+        ], device="cuda", non_tensor_fields=[], auto_refresh=True)
+        res0 = self.client.index(self.index_name_1).search("wow camel", device="cuda")
+        assert res0['hits'][0]["_id"] == "123"
+        assert len(res0['hits']) == 2
+        self.client.index(self.index_name_1).delete_documents(["123"], auto_refresh=True)
+        res1 = self.client.index(self.index_name_1).search("wow camel", device="cuda")
+        assert res1['hits'][0]["_id"] == "foo"
+        assert len(res1['hits']) == 1
+
+    def test_delete_docs_empty_ids(self):
+        self.client.create_index(index_name=self.index_name_1)
+        self.client.index(self.index_name_1).add_documents([{"abc": "efg", "_id": "123"}], device="cuda",
+                                                           non_tensor_fields=[])
+        try:
+            self.client.index(self.index_name_1).delete_documents([])
+            raise AssertionError
+        except MarqoWebError as e:
+            assert "can't be empty" in str(e) or "value_error.missing" in str (e)
+        res = self.client.index(self.index_name_1).get_document("123")
+        print(res)
+        assert "abc" in res

--- a/tests/api_tests/cuda/test_cuda_image_chunking.py
+++ b/tests/api_tests/cuda/test_cuda_image_chunking.py
@@ -47,7 +47,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (aking to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], device='cuda', non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], device='cuda', non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a', device="cuda")
@@ -90,7 +90,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], device='cuda', non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], device='cuda', non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a', device="cuda")

--- a/tests/api_tests/cuda/test_cuda_search.py
+++ b/tests/api_tests/cuda/test_cuda_search.py
@@ -48,7 +48,7 @@ class TestSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], device='cuda', non_tensor_fields=[])
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], device='cuda', non_tensor_fields=[], auto_refresh=True)
         search_res = self.client.index(self.index_name_1).search(
             "title about some doc", device="cuda")
         assert len(search_res["hits"]) == 1
@@ -76,7 +76,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], device='cuda', non_tensor_fields=[])
+        ], device='cuda', non_tensor_fields=[], auto_refresh=True)
         search_res = self.client.index(self.index_name_1).search(
             "this is a solid doc", device="cuda")
         assert d2 == self.strip_marqo_fields(search_res['hits'][0], strip_id=False)
@@ -97,7 +97,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], device="cuda", non_tensor_fields=[])
+        ], device="cuda", non_tensor_fields=[], auto_refresh=True)
 
         # Ensure that vector search works
         search_res = self.client.index(self.index_name_1).search(

--- a/tests/api_tests/cuda/test_cuda_sentence_chunking.py
+++ b/tests/api_tests/cuda/test_cuda_sentence_chunking.py
@@ -46,7 +46,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a', device="cuda")
@@ -79,7 +79,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[], auto_refresh=True)
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'
@@ -127,7 +127,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], device="cuda", non_tensor_fields=[], auto_refresh=True)
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'

--- a/tests/api_tests/test_add_documents.py
+++ b/tests/api_tests/test_add_documents.py
@@ -162,36 +162,6 @@ class TestAddDocuments(MarqoTestCase):
     def test_update_docs_updates_chunks(self):
         """TODO"""
 
-    # delete documents tests:
-
-    def test_delete_docs(self):
-        self.client.create_index(index_name=self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([
-            {"abc": "wow camel", "_id": "123"},
-            {"abc": "camels are cool", "_id": "foo"}
-        ], non_tensor_fields=[])
-        res0 = self.client.index(self.index_name_1).search("wow camel")
-        print("res0res0")
-        pprint.pprint(res0)
-        assert res0['hits'][0]["_id"] == "123"
-        assert len(res0['hits']) == 2
-        self.client.index(self.index_name_1).delete_documents(["123"])
-        res1 = self.client.index(self.index_name_1).search("wow camel")
-        assert res1['hits'][0]["_id"] == "foo"
-        assert len(res1['hits']) == 1
-
-    def test_delete_docs_empty_ids(self):
-        self.client.create_index(index_name=self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"abc": "efg", "_id": "123"}], non_tensor_fields=[])
-        try:
-            self.client.index(self.index_name_1).delete_documents([])
-            raise AssertionError
-        except MarqoWebError as e:
-            assert "can't be empty" in str(e) or "value_error.missing" in str (e)
-        res = self.client.index(self.index_name_1).get_document("123")
-        print(res)
-        assert "abc" in res
-
     # get documents tests :
 
     def test_get_document(self):

--- a/tests/api_tests/test_bulk_search.py
+++ b/tests/api_tests/test_bulk_search.py
@@ -46,7 +46,7 @@ class TestBulkSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[])
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[], auto_refresh=True)
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "title about some doc"
@@ -73,7 +73,7 @@ class TestBulkSearch(MarqoTestCase):
     def test_search_highlights(self):
         """Tests if show_highlights works and if the deprecation behaviour is expected"""
         self.client.create_index(index_name=self.index_name_1)
-        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}], non_tensor_fields=[])
+        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}], non_tensor_fields=[], auto_refresh=True)
         for params, expected_highlights_presence in [
                 ({}, True),
                 ({"showHighlights": False}, False),
@@ -101,7 +101,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], non_tensor_fields=[])
+        ], non_tensor_fields=[], auto_refresh=True)
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "this is a solid doc"
@@ -127,7 +127,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], non_tensor_fields=[])
+        ], non_tensor_fields=[], auto_refresh=True)
 
         # Ensure that vector search works
         resp = self.client.bulk_search([{
@@ -253,7 +253,7 @@ class TestBulkSearch(MarqoTestCase):
                         for i in range(num_docs)]
         
         self.client.index(index_name=self.index_name_1).add_documents(
-            docs, auto_refresh=False, client_batch_size=50, non_tensor_fields=[]
+            docs, auto_refresh=True, client_batch_size=50, non_tensor_fields=[]
         )
         self.client.index(index_name=self.index_name_1).refresh()
 

--- a/tests/api_tests/test_delete_documents.py
+++ b/tests/api_tests/test_delete_documents.py
@@ -1,0 +1,52 @@
+import copy
+import pprint
+from marqo.client import Client
+from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
+import unittest
+from tests.marqo_test import MarqoTestCase
+from marqo import enums
+from unittest import mock
+import numpy as np
+import pytest
+
+class TestDeleteDocuments(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def tearDown(self) -> None:
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def test_delete_docs(self):
+        self.client.create_index(index_name=self.index_name_1)
+        self.client.index(self.index_name_1).add_documents([
+            {"abc": "wow camel", "_id": "123"},
+            {"abc": "camels are cool", "_id": "foo"}
+        ], non_tensor_fields=[], auto_refresh=True)
+        res0 = self.client.index(self.index_name_1).search("wow camel")
+        assert res0['hits'][0]["_id"] == "123"
+        assert len(res0['hits']) == 2
+        self.client.index(self.index_name_1).delete_documents(["123"], auto_refresh=True)
+        res1 = self.client.index(self.index_name_1).search("wow camel")
+        assert res1['hits'][0]["_id"] == "foo"
+        assert len(res1['hits']) == 1
+
+    def test_delete_docs_empty_ids(self):
+        self.client.create_index(index_name=self.index_name_1)
+        self.client.index(self.index_name_1).add_documents([{"abc": "efg", "_id": "123"}], non_tensor_fields=[])
+        try:
+            self.client.index(self.index_name_1).delete_documents([])
+            raise AssertionError
+        except MarqoWebError as e:
+            assert "can't be empty" in str(e) or "value_error.missing" in str (e)
+        res = self.client.index(self.index_name_1).get_document("123")
+        print(res)
+        assert "abc" in res

--- a/tests/api_tests/test_demos.py
+++ b/tests/api_tests/test_demos.py
@@ -38,7 +38,7 @@ class TestDemo(MarqoTestCase):
                 S2Search is based in Melbourne. Melbourne has beautiful waterways running through it.
                 """
             },
-        ], non_tensor_fields=[])
+        ], non_tensor_fields=[], auto_refresh=True)
         print("\nSearching the phrase 'River' across all fields")
         pprint.pprint(client.index("cool-index-1").search("River"))
         # then we search specific searchable attributes. We can see how powerful semantic search is
@@ -63,7 +63,7 @@ class TestDemo(MarqoTestCase):
                                "mobility, life support, and communications for astronauts",
                 "_id": "article_591"
             }
-        ], non_tensor_fields=[])
+        ], non_tensor_fields=[], auto_refresh=True)
 
         results = mq.index("my-first-index").search(
             q="What is the best outfit to wear on the moon?"
@@ -91,7 +91,7 @@ class TestDemo(MarqoTestCase):
         r5 = mq.index("my-first-index").search('adventure', searchable_attributes=['Title'])
         assert len(r5["hits"]) == 2
 
-        r6 = mq.index("my-first-index").delete_documents(ids=["article_591", "article_602"])
+        r6 = mq.index("my-first-index").delete_documents(ids=["article_591", "article_602"], auto_refresh=True)
         assert r6['details']['deletedDocuments'] == 1
 
         rneg1 = mq.index("my-first-index").delete()

--- a/tests/api_tests/test_image_chunking.py
+++ b/tests/api_tests/test_image_chunking.py
@@ -49,7 +49,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (aking to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -92,7 +92,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -155,7 +155,7 @@ class TestImageChunking(MarqoTestCase):
             'location_1': temp_file_name_2},
         ]
 
-        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('brain', searchable_attributes=['location', 'location_1'])
@@ -205,7 +205,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -255,7 +255,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -299,7 +299,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a')

--- a/tests/api_tests/test_image_reranking.py
+++ b/tests/api_tests/test_image_reranking.py
@@ -54,7 +54,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://marqo-assets.s3.amazonaws.com/tests/images/ai_hippo_statue.png'},
         ]
 
-        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[], auto_refresh=True)
 
         ###### proper way to search over images
         # test the search works
@@ -125,7 +125,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://marqo-assets.s3.amazonaws.com/tests/images/ai_hippo_statue.png'},
         ]
 
-        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[], auto_refresh=True)
 
         # test Errors
         # # test the search works with the reranking and no searchable attributes
@@ -165,7 +165,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://marqo-assets.s3.amazonaws.com/tests/images/ai_hippo_statue.png'},
         ]
 
-        res = client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
+        res = client.index(self.index_name).add_documents(documents, non_tensor_fields=[], auto_refresh=True)
         print(res)
 
         # test Errors
@@ -208,7 +208,7 @@ class TestImageReranking(MarqoTestCase):
             'location': 'https://marqo-assets.s3.amazonaws.com/tests/images/ai_hippo_statue.png'},
         ]
 
-        client.index(self.index_name).add_documents(documents, non_tensor_fields=[])
+        client.index(self.index_name).add_documents(documents, non_tensor_fields=[], auto_refresh=True)
 
         ###### proper way to search over images
         # test the search works

--- a/tests/api_tests/test_score_modifiers_search.py
+++ b/tests/api_tests/test_score_modifiers_search.py
@@ -33,6 +33,7 @@ class TestScoreModifierSearch(MarqoTestCase):
                  },
             ], non_tensor_fields=["multiply_1", "multiply_2", "add_1", "add_2",
                                                        "filter"]
+            , auto_refresh=True
         )
 
         self.query = "what is the rider doing?"

--- a/tests/api_tests/test_search.py
+++ b/tests/api_tests/test_search.py
@@ -44,7 +44,7 @@ class TestSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[])
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[], auto_refresh=True)
         search_res = self.client.index(self.index_name_1).search(
             "title about some doc")
         assert len(search_res["hits"]) == 1
@@ -72,7 +72,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], non_tensor_fields=[])
+        ], non_tensor_fields=[], auto_refresh=True)
         search_res = self.client.index(self.index_name_1).search(
             "this is a solid doc")
         assert d2 == self.strip_marqo_fields(search_res['hits'][0], strip_id=False)
@@ -93,7 +93,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], non_tensor_fields=[])
+        ], non_tensor_fields=[], auto_refresh=True)
 
         # Ensure that vector search works
         search_res = self.client.index(self.index_name_1).search(
@@ -158,7 +158,7 @@ class TestSearch(MarqoTestCase):
                 "int_for_filtering": 1,
             }
         ]
-        res = self.client.index(self.index_name_1).add_documents(docs,auto_refresh=True, non_tensor_fields=[])
+        res = self.client.index(self.index_name_1).add_documents(docs, non_tensor_fields=[], auto_refresh=True)
 
         test_cases = (
             {   # filter string only (str)
@@ -286,7 +286,7 @@ class TestSearch(MarqoTestCase):
                     "Description": "A history of household pets",
                     "_id": "d2"
                 }
-            ], non_tensor_fields=[]
+            ], non_tensor_fields=[], auto_refresh=True
         )
         query = {
             "What are the best pets": 1

--- a/tests/api_tests/test_sentence_chunking.py
+++ b/tests/api_tests/test_sentence_chunking.py
@@ -47,7 +47,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # test the search works
         results = client.index(self.index_name).search('a')
@@ -80,7 +80,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'
@@ -128,7 +128,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1], non_tensor_fields=[])
+        client.index(self.index_name).add_documents([document1], non_tensor_fields=[], auto_refresh=True)
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'

--- a/tests/application_tests/test_asynchronous.py
+++ b/tests/application_tests/test_asynchronous.py
@@ -35,7 +35,7 @@ class TestAsync (marqo_test.MarqoTestCase):
             "_id": "56"
         }
         self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[])
+        self.client.index(self.index_name_1).add_documents([d1], non_tensor_fields=[], auto_refresh=True)
         assert self.client.index(self.index_name_1).get_stats()['numberOfDocuments'] == 1
 
         def significant_ingestion():

--- a/tests/application_tests/test_start_stop.py
+++ b/tests/application_tests/test_start_stop.py
@@ -40,7 +40,7 @@ class TestStartStop(marqo_test.MarqoTestCase):
             d2 = {"Title": "some frogs", "_id": "fact_2"}
             self._delete_index()
             self.client.create_index(self.index_name_1)
-            self.client.index(self.index_name_1).add_documents(documents=[d1, d2], non_tensor_fields=[])
+            self.client.index(self.index_name_1).add_documents(documents=[d1, d2], non_tensor_fields=[], auto_refresh=True)
             search_res_0 = self.client.index(self.index_name_1).search(q="General nature facts")
             assert (search_res_0["hits"][0]["_id"] == "fact_1") or (search_res_0["hits"][0]["_id"] == "fact_2")
             assert len(search_res_0["hits"]) == 2


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Tests with add docs or delete docs and search immediately after fail now, due to default `auto_refresh` value now being `False` instead of `True`.

* **What is the new behavior (if this is a feature change)?**
- Necessary tests with `add_documents` and `delete_documents` have `auto_refresh=True` added to them.
- Delete docs tests broken out into separate file.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

