### PR TITLE
Pandu/fix test multiple env vars

### DIFF
--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -23,8 +23,10 @@ class TestCreateIndex(MarqoTestCase):
 
         client.create_index(self.index_name_bulk_substring)
         try:
-            client.create_index('bulk')
-            raise AssertionError('created index with illegal name `bulk`!')
+            create_index_res = client.create_index('bulk')
+            raise AssertionError(
+                f'created index with illegal name `bulk`! '
+                f'Create index response: {create_index_res}')
         except MarqoWebError as e:
             assert e.code == 'invalid_index_name'
         # ensure the index was not accidentally created despite the error:

--- a/tests/application_tests/test_env_var_changes.py
+++ b/tests/application_tests/test_env_var_changes.py
@@ -22,6 +22,7 @@ from tests import utilities
 from marqo import Client
 from marqo.errors import MarqoApiError, MarqoWebError
 import json
+import os
 
 
 class TestEnvVarChanges(marqo_test.MarqoTestCase):
@@ -220,7 +221,8 @@ class TestEnvVarChanges(marqo_test.MarqoTestCase):
         #         or (
         #                 "Unverified HTTPS request is being made to host 'localhost'. "
         #                 "Adding certificate verification is strongly advised." in log_blob))
-        assert 'Status: Downloaded newer image for marqoai/marqo-os' in log_blob
+        if "DIND" in os.environ["TESTING_CONFIGURATION"]:
+            assert 'Status: Downloaded newer image for marqoai/marqo-os' in log_blob
         assert 'FutureWarning: Importing `GenerationMixin`' in log_blob
         assert 'Called redis-server command' in log_blob
 


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: docker download log output is only checked for DIND test environments

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No 

Testing was against a marqo test image, which is based of current Marqo mainline: https://github.com/marqo-ai/marqo/commit/7f03224449facc0e9ac78e73b78c5af06b435cb0
