### PR TITLE
add sleep before retrieving marqo log blobs before running assertion …

### DIFF
--- a/tests/application_tests/test_env_var_changes.py
+++ b/tests/application_tests/test_env_var_changes.py
@@ -329,6 +329,8 @@ class TestBackendRetries(marqo_test.MarqoTestCase):
                     assert e.__class__ == MarqoWebError
                     pass
 
+                time.sleep(10) # add sleep to let marqo print all occurrences of retry_text
+
                 log_blob = utilities.retrieve_docker_logs("marqo", start_time)
 
                 retry_text = "BackendCommunicationError encountered... Retrying request to"
@@ -371,6 +373,8 @@ class TestBackendRetries(marqo_test.MarqoTestCase):
             except Exception as e:
                 assert e.__class__ == MarqoWebError
                 pass
+
+            time.sleep(10) # add sleep to let marqo print all occurrences of retry_text
 
             log_blob = utilities.retrieve_docker_logs("marqo", start_time)
 
@@ -415,6 +419,8 @@ class TestBackendRetries(marqo_test.MarqoTestCase):
                 except Exception as e:
                     assert e.__class__ == MarqoWebError
                     pass
+
+                time.sleep(10) # add sleep to let marqo print all occurrences of retry_text
 
                 log_blob = utilities.retrieve_docker_logs("marqo", start_time)
 

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -126,11 +126,14 @@ def attach_docker_logs(container_name: str, log_collection: typing.List, start_t
         start_time (str): A string representing the start time stamp to get docker logs
             must be in the format: "%Y-%m-%dT%H:%M:%S"
     """
-    
-    start_time_command = f"--since={start_time}" if start_time != None else ""
+
+    commands =  ["docker", "logs", container_name]
+
+    if start_time != None:
+        commands.append(f"--since={start_time}")
     
     completed_process = subprocess.run(
-        ["docker", "logs", container_name, start_time_command],
+        commands,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True


### PR DESCRIPTION
…tests on retry tests

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix for api test suite on retry tests.

* **What is the current behavior?** (You can also link to an open issue here)
sometimes there is delay in logging before doing the assertion check due to concurrency

* **What is the new behavior (if this is a feature change)?**
add some time.sleep() methods to ensure all retry text are found in logs before running assertion check

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

