### PR TITLE
Added content_type="document" to embed requests for prefix implementation

### DIFF
--- a/tests/api_tests/test_embed.py
+++ b/tests/api_tests/test_embed.py
@@ -12,6 +12,7 @@ class TestEmbed(MarqoTestCase):
 
         cls.structured_index_name = "structured_" + str(uuid.uuid4()).replace('-', '')
         cls.unstructured_index_name = "unstructured_" + str(uuid.uuid4()).replace('-', '')
+        cls.unstructured_index_non_e5 = "unstructured_non_e5_" + str(uuid.uuid4()).replace('-', '')
 
         cls.create_indexes([
             {
@@ -27,16 +28,21 @@ class TestEmbed(MarqoTestCase):
             {
                 "indexName": cls.unstructured_index_name,
                 "type": "unstructured",
+            },
+            {
+                "indexName": cls.unstructured_index_non_e5,
+                "type": "unstructured",
+                "model": "sentence-transformers/all-MiniLM-L6-v2"
             }
         ])
 
-        cls.indexes_to_delete = [cls.structured_index_name, cls.unstructured_index_name]
+        cls.indexes_to_delete = [cls.structured_index_name, cls.unstructured_index_name, cls.unstructured_index_non_e5]
 
     def test_embed_single_string(self):
         """Embeds a string. Use add docs and get docs with tensor facets to ensure the vector is correct.
                 Checks the basic functionality and response structure"""
 
-        test_cases = [self.structured_index_name, self.unstructured_index_name]
+        test_cases = [self.structured_index_name, self.unstructured_index_name, self.unstructured_index_non_e5]
 
         for test_index_name in test_cases:
             with (self.subTest(test_index_name)):
@@ -53,7 +59,10 @@ class TestEmbed(MarqoTestCase):
                     document_id="doc1", expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed("Jimmy Butler is the GOAT.", device="cpu", content_type="document")
+                if test_index_name == self.unstructured_index_non_e5:
+                    embed_res = self.client.index(test_index_name).embed("Jimmy Butler is the GOAT.", device="cpu")
+                else:
+                    embed_res = self.client.index(test_index_name).embed("Jimmy Butler is the GOAT.", device="cpu", content_type="document")
 
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], "Jimmy Butler is the GOAT.")
@@ -63,7 +72,7 @@ class TestEmbed(MarqoTestCase):
     def test_embed_with_device(self):
         """Embeds a string with device parameter. Use add docs and get docs with tensor facets to ensure the vector is correct.
                         Checks the basic functionality and response structure"""
-        test_cases = [self.structured_index_name, self.unstructured_index_name]
+        test_cases = [self.structured_index_name, self.unstructured_index_name, self.unstructured_index_non_e5]
 
         for test_index_name in test_cases:
             with (self.subTest(test_index_name)):
@@ -80,7 +89,11 @@ class TestEmbed(MarqoTestCase):
                     document_id="doc1", expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed(content="Jimmy Butler is the GOAT.", device="cpu", content_type="document")
+                if test_index_name == self.unstructured_index_non_e5:
+                    embed_res = self.client.index(test_index_name).embed(content="Jimmy Butler is the GOAT.", device="cpu")
+                else:
+                    embed_res = self.client.index(test_index_name).embed(content="Jimmy Butler is the GOAT.", device="cpu", content_type="document")
+
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], "Jimmy Butler is the GOAT.")
                 self.assertTrue(np.allclose(embed_res["embeddings"][0], retrieved_d1["_tensor_facets"][0] ["_embedding"], atol=1e-6))
@@ -88,7 +101,7 @@ class TestEmbed(MarqoTestCase):
     def test_embed_single_dict(self):
         """Embeds a dict. Use add docs and get docs with tensor facets to ensure the vector is correct.
                         Checks the basic functionality and response structure"""
-        test_cases = [self.structured_index_name, self.unstructured_index_name]
+        test_cases = [self.structured_index_name, self.unstructured_index_name, self.unstructured_index_non_e5]
 
         for test_index_name in test_cases:
             with (self.subTest(test_index_name)):
@@ -105,7 +118,10 @@ class TestEmbed(MarqoTestCase):
                     document_id="doc1", expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed(content={"Jimmy Butler is the GOAT.": 1},content_type="document")
+                if test_index_name == self.unstructured_index_non_e5:
+                    embed_res = self.client.index(test_index_name).embed(content={"Jimmy Butler is the GOAT.": 1})
+                else:
+                    embed_res = self.client.index(test_index_name).embed(content={"Jimmy Butler is the GOAT.": 1}, content_type="document")
 
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], {"Jimmy Butler is the GOAT.": 1})
@@ -114,7 +130,7 @@ class TestEmbed(MarqoTestCase):
     def test_embed_list_content(self):
         """Embeds a list with string and dict. Use add docs and get docs with tensor facets to ensure the vector is correct.
                                 Checks the basic functionality and response structure"""
-        test_cases = [self.structured_index_name, self.unstructured_index_name]
+        test_cases = [self.structured_index_name, self.unstructured_index_name, self.unstructured_index_non_e5]
 
         for test_index_name in test_cases:
             with (self.subTest(test_index_name)):
@@ -135,14 +151,15 @@ class TestEmbed(MarqoTestCase):
                     document_ids=["doc1", "doc2"], expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed(
-                    content=[{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."],
-                    content_type="document"
-                )
-
-                print(f"model: {self.client.index(test_index_name).get_settings()['model']}")
-                print(f"retrieved_docs: {retrieved_docs}")
-                print(f"embed_res: {embed_res}")
+                if test_index_name == self.unstructured_index_non_e5:
+                    embed_res = self.client.index(test_index_name).embed(
+                        content=[{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."],
+                    )
+                else:
+                    embed_res = self.client.index(test_index_name).embed(
+                        content=[{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."],
+                        content_type="document"
+                    )
 
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], [{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."])

--- a/tests/api_tests/test_embed.py
+++ b/tests/api_tests/test_embed.py
@@ -53,7 +53,7 @@ class TestEmbed(MarqoTestCase):
                     document_id="doc1", expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed("Jimmy Butler is the GOAT.")
+                embed_res = self.client.index(test_index_name).embed("Jimmy Butler is the GOAT.", device="cpu", content_type="document")
 
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], "Jimmy Butler is the GOAT.")
@@ -80,7 +80,7 @@ class TestEmbed(MarqoTestCase):
                     document_id="doc1", expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed(content="Jimmy Butler is the GOAT.", device="cpu")
+                embed_res = self.client.index(test_index_name).embed(content="Jimmy Butler is the GOAT.", device="cpu", content_type="document")
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], "Jimmy Butler is the GOAT.")
                 self.assertTrue(np.allclose(embed_res["embeddings"][0], retrieved_d1["_tensor_facets"][0] ["_embedding"], atol=1e-6))
@@ -105,7 +105,7 @@ class TestEmbed(MarqoTestCase):
                     document_id="doc1", expose_facets=True)
 
                 # Call embed
-                embed_res = self.client.index(test_index_name).embed(content={"Jimmy Butler is the GOAT.": 1})
+                embed_res = self.client.index(test_index_name).embed(content={"Jimmy Butler is the GOAT.": 1},content_type="document")
 
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], {"Jimmy Butler is the GOAT.": 1})
@@ -136,8 +136,13 @@ class TestEmbed(MarqoTestCase):
 
                 # Call embed
                 embed_res = self.client.index(test_index_name).embed(
-                    content=[{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."]
+                    content=[{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."],
+                    content_type="document"
                 )
+
+                print(f"model: {self.client.index(test_index_name).get_settings()['model']}")
+                print(f"retrieved_docs: {retrieved_docs}")
+                print(f"embed_res: {embed_res}")
 
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], [{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."])


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added content_type="document" to embed requests, which is a new field added in https://github.com/marqo-ai/marqo/pull/821

* **What is the current behavior?** (You can also link to an open issue here)
Without defining the field content_type, content_type defaults to "query" prefixes, which makes the tests fail when comparing to embeddings from add_documents since add_documents default to "document" prefixes.

* **What is the new behavior (if this is a feature change)?**
By defining content_type defaults="document" we make sure that the prefixes prepended to document chunks are the same for both embed calls and add_document calls.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)'
None


* **Other information**:

