### PR TITLE
Add tests for concurrent create/delete index

### DIFF
--- a/scripts/start_local_marqo.sh
+++ b/scripts/start_local_marqo.sh
@@ -22,6 +22,7 @@ docker run -d --name marqo --privileged -p 8882:8882 --add-host host.docker.inte
     -e VESPA_CONFIG_URL="http://host.docker.internal:19071" \
     -e VESPA_DOCUMENT_URL="http://host.docker.internal:8080" \
     -e VESPA_QUERY_URL="http://host.docker.internal:8080" \
+    -e ZOOKEEPER_HOSTS="host.docker.internal:2181" \
     -e MARQO_MODELS_TO_PRELOAD='[]' \
     ${@:+"$@"} "$MARQO_DOCKER_IMAGE" --memory=8g
 set +x

--- a/scripts/start_vespa.py
+++ b/scripts/start_vespa.py
@@ -27,7 +27,7 @@ def start_vespa() -> None:
     os.system("docker run --detach "
               "--name vespa "
               "--hostname vespa-container "
-              "--publish 8080:8080 --publish 19071:19071 "
+              "--publish 8080:8080 --publish 19071:19071 --publish 2181:2181 "
               "vespaengine/vespa")
 
 

--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -371,5 +371,3 @@ class TestCreateIndex(MarqoTestCase):
         res = self.client.delete_index(index_name=index_name)
         self.assertEqual(res["message"], f"Index {index_name} not found")
         self.assertEqual(res["code"], "index_not_found")
-
-

--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -330,12 +330,12 @@ class TestCreateIndex(MarqoTestCase):
 
         with self.assertRaises(MarqoWebError) as e:
             self.client.create_index(index_name=index_name_2)
-        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+        self.assertIn("Another index creation/deletion operation is in progress",
                       str(e.exception))
 
         with self.assertRaises(MarqoWebError) as e:
             self.client.delete_index(index_name=index_name_1)
-        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+        self.assertIn("Another index creation/deletion operation is in progress",
                       str(e.exception))
         t1.join()
 
@@ -356,12 +356,12 @@ class TestCreateIndex(MarqoTestCase):
 
         with self.assertRaises(MarqoWebError) as e:
             self.client.create_index(index_name=index_name_2)
-        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+        self.assertIn("Another index creation/deletion operation is in progress",
                       str(e.exception))
 
         with self.assertRaises(MarqoWebError) as e:
             self.client.delete_index(index_name=index_name_1)
-        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+        self.assertIn("Another index creation/deletion operation is in progress",
                       str(e.exception))
         t1.join()
 

--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -1,4 +1,6 @@
 import uuid
+import threading
+import time
 
 from marqo.errors import MarqoWebError
 
@@ -310,3 +312,64 @@ class TestCreateIndex(MarqoTestCase):
 
         self.assertEqual([{'features': ['lexical_search', 'filter'], 'name': 'my_custom_vector', 'type': 'custom_vector'}],
                          index_settings['allFields'])
+
+    def test_createIndexCanBlockOtherRequests(self):
+        """Tests if create_index request can block other create/delete index requests."""
+        # Create a new index
+
+        index_name_1 = "test_index_" + str(uuid.uuid4())
+        index_name_2 = "test_index_" + str(uuid.uuid4())
+
+        def create_index():
+            self.client.create_index(index_name=index_name_1)
+            self.indexes_to_delete.append(index_name_1)
+
+        t1 = threading.Thread(target=create_index)
+        t1.start()
+        time.sleep(0.5)
+
+        with self.assertRaises(MarqoWebError) as e:
+            self.client.create_index(index_name=index_name_2)
+        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+                      str(e.exception))
+
+        with self.assertRaises(MarqoWebError) as e:
+            self.client.delete_index(index_name=index_name_1)
+        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+                      str(e.exception))
+        t1.join()
+
+    def test_deleteIndexCanBlockOtherRequests(self):
+        """Test if delete_index request can block other create/delete index requests."""
+        index_name_1 = "test_index_" + str(uuid.uuid4())
+        index_name_2 = "test_index_" + str(uuid.uuid4())
+
+        # Create a dummy index for deletion
+        self.client.create_index(index_name=index_name_1)
+
+        def delete_index():
+            self.client.delete_index(index_name=index_name_1)
+
+        t1 = threading.Thread(target=delete_index)
+        t1.start()
+        time.sleep(0.5)
+
+        with self.assertRaises(MarqoWebError) as e:
+            self.client.create_index(index_name=index_name_2)
+        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+                      str(e.exception))
+
+        with self.assertRaises(MarqoWebError) as e:
+            self.client.delete_index(index_name=index_name_1)
+        self.assertIn("Another index creation/deletion is in progress. Please try again later.",
+                      str(e.exception))
+        t1.join()
+
+    def test_indexNotFoundErrorNotRaised(self):
+        """Test to ensure index_not_found error is not raised but returned as message in delete_index response"""
+        index_name = "test_index_" + str(uuid.uuid4())
+        res = self.client.delete_index(index_name=index_name)
+        self.assertEqual(res["message"], f"Index {index_name} not found")
+        self.assertEqual(res["code"], "index_not_found")
+
+

--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -328,16 +328,18 @@ class TestCreateIndex(MarqoTestCase):
         t1.start()
         time.sleep(0.5)
 
-        with self.assertRaises(MarqoWebError) as e:
-            self.client.create_index(index_name=index_name_2)
-        self.assertIn("Another index creation/deletion operation is in progress",
-                      str(e.exception))
+        try:
+            with self.assertRaises(MarqoWebError) as e:
+                self.client.create_index(index_name=index_name_2)
+            self.assertIn("Another index creation/deletion operation is in progress",
+                          str(e.exception))
 
-        with self.assertRaises(MarqoWebError) as e:
-            self.client.delete_index(index_name=index_name_1)
-        self.assertIn("Another index creation/deletion operation is in progress",
-                      str(e.exception))
-        t1.join()
+            with self.assertRaises(MarqoWebError) as e:
+                self.client.delete_index(index_name=index_name_1)
+            self.assertIn("Another index creation/deletion operation is in progress",
+                          str(e.exception))
+        finally:
+            t1.join()
 
     def test_deleteIndexCanBlockOtherRequests(self):
         """Test if delete_index request can block other create/delete index requests."""
@@ -354,16 +356,18 @@ class TestCreateIndex(MarqoTestCase):
         t1.start()
         time.sleep(0.5)
 
-        with self.assertRaises(MarqoWebError) as e:
-            self.client.create_index(index_name=index_name_2)
-        self.assertIn("Another index creation/deletion operation is in progress",
-                      str(e.exception))
+        try:
+            with self.assertRaises(MarqoWebError) as e:
+                self.client.create_index(index_name=index_name_2)
+            self.assertIn("Another index creation/deletion operation is in progress",
+                          str(e.exception))
 
-        with self.assertRaises(MarqoWebError) as e:
-            self.client.delete_index(index_name=index_name_1)
-        self.assertIn("Another index creation/deletion operation is in progress",
-                      str(e.exception))
-        t1.join()
+            with self.assertRaises(MarqoWebError) as e:
+                self.client.delete_index(index_name=index_name_1)
+            self.assertIn("Another index creation/deletion operation is in progress",
+                          str(e.exception))
+        finally:
+            t1.join()
 
     def test_indexNotFoundErrorNotRaised(self):
         """Test to ensure index_not_found error is not raised but returned as message in delete_index response"""


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix 

* **What is the current behavior?** (You can also link to an open issue here)
we don't have protection on concurrent index creation/deletion

* **What is the new behavior (if this is a feature change)?**
we raise an error and block the index creation/deletion request, when there is a deployment in progress

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
no
