### PR TITLE
Adding api test to verify that the model data is blocked in model properties if a model is a marqtuned model.

### DIFF
--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -241,7 +241,7 @@ class TestCreateIndex(MarqoTestCase):
                 }
             },
             "tensorFields": ["text_field_1", "text_field_2",
-                            "video_field_1", "video_field_2", "audio_field", "image_field"],
+                             "video_field_1", "video_field_2", "audio_field", "image_field"],
             "allFields": [
                 {"features": [], "name": "text_field_1", "type": "text"},
                 {"features": [], "name": "text_field_2", "type": "text"},
@@ -335,6 +335,64 @@ class TestCreateIndex(MarqoTestCase):
                           "dimensions": 384,
                           "tokens": 128,
                           "type": "sbert"}, index_settings['modelProperties'])
+
+    def test_index_settings_should_hide_model_internal_data_if_model_is_marqtune_model(self):
+        self.client.create_index(index_name=self.index_name,
+                                 type="structured",
+                                 model="marqtune/model-id/checkpoint",
+                                 model_properties={
+                                     "isMarqtuneModel": True,
+                                     "name": "ViT-B-32",
+                                     "dimensions": 512,
+                                     "model_location": {
+                                         "s3": {
+                                             "Bucket": "marqtune-public-bucket",
+                                             "Key": "marqo-test-open-clip-model/epoch_2.pt",
+                                         },
+                                         "auth_required": False
+                                     },
+                                     "type": "open_clip",
+                                 },
+                                 all_fields=[{"name": "test", "type": "text", "features": ["lexical_search"]}],
+                                 tensor_fields=["test"])
+
+        index_settings = self.client.index(self.index_name).get_settings()
+        self.assertEqual("marqtune/model-id/checkpoint", index_settings['model'])
+        self.assertEqual({'isMarqtuneModel': True}, index_settings['modelProperties'])
+
+    def test_index_settings_should_not_hide_model_internal_data_if_model_is_not_marqtune_model(self):
+        self.client.create_index(index_name=self.index_name,
+                                 type="structured",
+                                 model="marqtune/model-id/checkpoint",
+                                 model_properties={
+                                     "name": "ViT-B-32",
+                                     "dimensions": 512,
+                                     "model_location": {
+                                         "s3": {
+                                             "Bucket": "marqtune-public-bucket",
+                                             "Key": "marqo-test-open-clip-model/epoch_1.pt",
+                                         },
+                                         "auth_required": False
+                                     },
+                                     "type": "open_clip",
+                                 },
+                                 all_fields=[{"name": "test", "type": "text", "features": ["lexical_search"]}],
+                                 tensor_fields=["test"])
+
+        index_settings = self.client.index(self.index_name).get_settings()
+        self.assertEqual("marqtune/model-id/checkpoint", index_settings['model'])
+        self.assertEqual({
+            "name": "ViT-B-32",
+            "dimensions": 512,
+            "model_location": {
+                "s3": {
+                    "Bucket": "marqtune-public-bucket",
+                    "Key": "marqo-test-open-clip-model/epoch_1.pt",
+                },
+                "auth_required": False
+            },
+            "type": "open_clip",
+        }, index_settings['modelProperties'])
 
     def test_create_structured_image_index_with_preprocessing(self):
         self.client.create_index(index_name=self.index_name,

--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -336,64 +336,6 @@ class TestCreateIndex(MarqoTestCase):
                           "tokens": 128,
                           "type": "sbert"}, index_settings['modelProperties'])
 
-    def test_index_settings_should_hide_model_internal_data_if_model_is_marqtune_model(self):
-        self.client.create_index(index_name=self.index_name,
-                                 type="structured",
-                                 model="marqtune/model-id/checkpoint",
-                                 model_properties={
-                                     "isMarqtuneModel": True,
-                                     "name": "ViT-B-32",
-                                     "dimensions": 512,
-                                     "model_location": {
-                                         "s3": {
-                                             "Bucket": "marqtune-public-bucket",
-                                             "Key": "marqo-test-open-clip-model/epoch_2.pt",
-                                         },
-                                         "auth_required": False
-                                     },
-                                     "type": "open_clip",
-                                 },
-                                 all_fields=[{"name": "test", "type": "text", "features": ["lexical_search"]}],
-                                 tensor_fields=["test"])
-
-        index_settings = self.client.index(self.index_name).get_settings()
-        self.assertEqual("marqtune/model-id/checkpoint", index_settings['model'])
-        self.assertEqual({'isMarqtuneModel': True}, index_settings['modelProperties'])
-
-    def test_index_settings_should_not_hide_model_internal_data_if_model_is_not_marqtune_model(self):
-        self.client.create_index(index_name=self.index_name,
-                                 type="structured",
-                                 model="marqtune/model-id/checkpoint",
-                                 model_properties={
-                                     "name": "ViT-B-32",
-                                     "dimensions": 512,
-                                     "model_location": {
-                                         "s3": {
-                                             "Bucket": "marqtune-public-bucket",
-                                             "Key": "marqo-test-open-clip-model/epoch_1.pt",
-                                         },
-                                         "auth_required": False
-                                     },
-                                     "type": "open_clip",
-                                 },
-                                 all_fields=[{"name": "test", "type": "text", "features": ["lexical_search"]}],
-                                 tensor_fields=["test"])
-
-        index_settings = self.client.index(self.index_name).get_settings()
-        self.assertEqual("marqtune/model-id/checkpoint", index_settings['model'])
-        self.assertEqual({
-            "name": "ViT-B-32",
-            "dimensions": 512,
-            "model_location": {
-                "s3": {
-                    "Bucket": "marqtune-public-bucket",
-                    "Key": "marqo-test-open-clip-model/epoch_1.pt",
-                },
-                "auth_required": False
-            },
-            "type": "open_clip",
-        }, index_settings['modelProperties'])
-
     def test_create_structured_image_index_with_preprocessing(self):
         self.client.create_index(index_name=self.index_name,
                                  type="structured",

--- a/tests/api_tests/test_index_settings.py
+++ b/tests/api_tests/test_index_settings.py
@@ -1,0 +1,80 @@
+import uuid
+
+from tests.marqo_test import MarqoTestCase
+
+
+class TestIndexSettings(MarqoTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        cls.marqtuned_index_name = "marqtuned_" + str(uuid.uuid4()).replace('-', '')
+        cls.non_marqtuned_index_name = "non_marqtuned_" + str(uuid.uuid4()).replace('-', '')
+
+        cls.create_indexes([
+            {
+                "indexName": cls.marqtuned_index_name,
+                "model": "marqtune/model-id/checkpoint",
+                "modelProperties": {
+                    "isMarqtuneModel": True,
+                    "name": "ViT-B-32",
+                    "dimensions": 512,
+                    "model_location": {
+                        "s3": {
+                            "Bucket": "marqtune-public-bucket",
+                            "Key": "marqo-test-open-clip-model/epoch_2.pt",
+                        },
+                        "auth_required": False
+                    },
+                    "type": "open_clip",
+                },
+                "all_fields": [{"name": "test", "type": "text", "features": ["lexical_search"]}],
+                "tensor_fields": ["test"]
+            },
+            {
+                "indexName": cls.non_marqtuned_index_name,
+                "model": "non-marqtune/model-id/checkpoint",
+                "modelProperties": {
+                    "isMarqtuneModel": False,
+                    "name": "ViT-B-32",
+                    "dimensions": 512,
+                    "model_location": {
+                        "s3": {
+                            "Bucket": "marqtune-public-bucket",
+                            "Key": "marqo-test-open-clip-model/epoch_2.pt",
+                        },
+                        "auth_required": False
+                    },
+                    "type": "open_clip",
+                },
+                "all_fields": [{"name": "test", "type": "text", "features": ["lexical_search"]}],
+                "tensor_fields": ["test"]
+            }
+        ])
+
+        cls.indexes_to_delete = [cls.marqtuned_index_name, cls.non_marqtuned_index_name]
+
+    def test_marqtune_index_settings(self):
+        with self.subTest(msg="Hide all model properties except isMarqtuneModel"):
+            index_settings = self.client.index(self.marqtuned_index_name).get_settings()
+            self.assertEqual("marqtune/model-id/checkpoint", index_settings['model'])
+            self.assertEqual({
+                "isMarqtuneModel": True,
+            }, index_settings['modelProperties'])
+
+        with self.subTest(msg="Don't hide any model properties"):
+            index_settings = self.client.index(self.non_marqtuned_index_name).get_settings()
+            self.assertEqual("non-marqtune/model-id/checkpoint", index_settings['model'])
+            self.assertEqual({
+                "isMarqtuneModel": False,
+                "name": "ViT-B-32",
+                "dimensions": 512,
+                "model_location": {
+                    "s3": {
+                        "Bucket": "marqtune-public-bucket",
+                        "Key": "marqo-test-open-clip-model/epoch_2.pt",
+                    },
+                    "auth_required": False
+                },
+                "type": "open_clip",
+            }, index_settings['modelProperties'])

--- a/tests/api_tests/test_index_settings.py
+++ b/tests/api_tests/test_index_settings.py
@@ -27,9 +27,7 @@ class TestIndexSettings(MarqoTestCase):
                         "auth_required": False
                     },
                     "type": "open_clip",
-                },
-                "all_fields": [{"name": "test", "type": "text", "features": ["lexical_search"]}],
-                "tensor_fields": ["test"]
+                }
             },
             {
                 "indexName": cls.non_marqtuned_index_name,
@@ -46,9 +44,7 @@ class TestIndexSettings(MarqoTestCase):
                         "auth_required": False
                     },
                     "type": "open_clip",
-                },
-                "all_fields": [{"name": "test", "type": "text", "features": ["lexical_search"]}],
-                "tensor_fields": ["test"]
+                }
             }
         ])
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)


Added api test for the feature that hides internal model data if a model is flagged as a Marqtune model in the/indexes/settings response. 

* What is the current behavior? 
Currently, the model properties in index settings include internal model data, such as the model's name, dimensions, and model location, even if the model is a Marqtune model. This could expose internal model details that should remain within Marqo ecosystem.

* What is the new behavior (if this is a feature change)?
With this change, if a model is marked as a Marqtune model using the "isMarqtuneModel" property, the index settings API will block internal model data, returning only the "isMarqtuneModel": True property in the response. This aligns with internal implementation of Marqtune models.