### PR TITLE
Fix the error message for concurrent index operation test

### DIFF
--- a/scripts/start_cuda_docker_marqo.sh
+++ b/scripts/start_cuda_docker_marqo.sh
@@ -15,6 +15,7 @@ docker run -d --name marqo --gpus all --privileged -p 8882:8882 --add-host host.
   -e MARQO_ENABLE_BATCH_APIS=TRUE \
   -e MARQO_MAX_CUDA_MODEL_MEMORY=15 \
   -e MARQO_MAX_CPU_MODEL_MEMORY=15 \
+  -e MARQO_INDEX_DEPLOYMENT_LOCK_TIMEOUT=0 \
     ${@:+"$@"} "$MARQO_DOCKER_IMAGE"
 set +x
 

--- a/scripts/start_docker_marqo.sh
+++ b/scripts/start_docker_marqo.sh
@@ -16,6 +16,7 @@ set -x
 docker run -d --name marqo -it -p 8882:8882 \
     -e MARQO_ENABLE_BATCH_APIS=TRUE \
     -e "MARQO_MAX_CPU_MODEL_MEMORY=1.6" \
+    -e MARQO_INDEX_DEPLOYMENT_LOCK_TIMEOUT=0 \
     ${@:+"$@"} "$MARQO_DOCKER_IMAGE"
 set +x
 

--- a/scripts/start_local_marqo.sh
+++ b/scripts/start_local_marqo.sh
@@ -23,6 +23,7 @@ docker run -d --name marqo --privileged -p 8882:8882 --add-host host.docker.inte
     -e VESPA_DOCUMENT_URL="http://host.docker.internal:8080" \
     -e VESPA_QUERY_URL="http://host.docker.internal:8080" \
     -e ZOOKEEPER_HOSTS="host.docker.internal:2181" \
+    -e MARQO_INDEX_DEPLOYMENT_LOCK_TIMEOUT=0 \
     -e MARQO_MODELS_TO_PRELOAD='[]' \
     ${@:+"$@"} "$MARQO_DOCKER_IMAGE" --memory=8g
 set +x

--- a/tests/api_tests/test_create_index.py
+++ b/tests/api_tests/test_create_index.py
@@ -469,12 +469,12 @@ class TestCreateIndex(MarqoTestCase):
         try:
             with self.assertRaises(MarqoWebError) as e:
                 self.client.create_index(index_name=index_name_2)
-            self.assertIn("Another index creation/deletion operation is in progress",
+            self.assertIn("Your indexes are being updated. Please try again shortly.",
                           str(e.exception))
 
             with self.assertRaises(MarqoWebError) as e:
                 self.client.delete_index(index_name=index_name_1)
-            self.assertIn("Another index creation/deletion operation is in progress",
+            self.assertIn("Your indexes are being updated. Please try again shortly.",
                           str(e.exception))
         finally:
             t1.join()
@@ -497,12 +497,12 @@ class TestCreateIndex(MarqoTestCase):
         try:
             with self.assertRaises(MarqoWebError) as e:
                 self.client.create_index(index_name=index_name_2)
-            self.assertIn("Another index creation/deletion operation is in progress",
+            self.assertIn("Your indexes are being updated. Please try again shortly.",
                           str(e.exception))
 
             with self.assertRaises(MarqoWebError) as e:
                 self.client.delete_index(index_name=index_name_1)
-            self.assertIn("Another index creation/deletion operation is in progress",
+            self.assertIn("Your indexes are being updated. Please try again shortly.",
                           str(e.exception))
         finally:
             t1.join()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update error message

* **What is the current behavior?** (You can also link to an open issue here)
The error message raised by concurrent index operation was `Another index creation/deletion operation is in progress`

* **What is the new behavior (if this is a feature change)?**
The error message raised by concurrent index operation is `Your indexes are being updated. Please try again shortly.` This is because add_documents requests might update index after 2.13, we need a more generic error message. 

We introduced an env var `MARQO_INDEX_DEPLOYMENT_LOCK_TIMEOUT` to config distributed lock timeout, default is 5 seconds. To avoid flakiness of the concurrent index operation test, we override it to 0 in all api tests.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* No


* **Other information**:

